### PR TITLE
Replace alt image by product title if not set

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -26,7 +26,7 @@
   {block name='product_cover'}
     <div class="product-cover">
       {if $product.cover}
-        <img class="js-qv-product-cover" src="{$product.cover.bySize.large_default.url}" alt="{$product.cover.legend}" title="{$product.cover.legend}" style="width:100%;" itemprop="image">
+        <img class="js-qv-product-cover" src="{$product.cover.bySize.large_default.url}" alt="{($product.cover.legend != '') ? $product.cover.legend : $product.name}" title="{$product.cover.legend}" style="width:100%;" itemprop="image">
         <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
           <i class="material-icons zoom-in">search</i>
         </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Replace alt image by product title if not set for better SEO
| Type?         | improvement
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | No
| How to test?  | Check "alt" field for a product image without legend field set.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
