### PR TITLE
Check if $field['value'] is set before display it

### DIFF
--- a/classes/webservice/WebserviceOutputXML.php
+++ b/classes/webservice/WebserviceOutputXML.php
@@ -135,7 +135,7 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
                 $ret .= ' read_only="true"';
             }
 
-            if ($field['value'] !== '') {
+            if (!empty($field['value'])) {
                 $node_content .= '<![CDATA[' . $field['value'] . ']]>';
             }
         }


### PR DESCRIPTION
Update of PR #12213 to fix #12056

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Check if $field['value'] is set before display it
| Type?         | bug fix
| Category?     | WS
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #12213 
| How to test?  | Check API with NULL values in place of empty values into database. eg: try api/customers/1 URL with a "website" or "company" value set to NULL into DB in place of empty field.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/12213)
<!-- Reviewable:end -->
